### PR TITLE
Expose http binding to client application

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is a vue-cli 3.x plugin to add an Node Express server in your Vue project.
 - Included fully customizable Express Server:
   - Just add your api routes into your project (with import/export support) without thinking to something else.
   - Optional automatic fallback to the Vue app, to serve both the api and the application with only one command. 
+  - Optional socket.io support.
 - (soon) Included optional example routes and components.
 
 ## Table of contents

--- a/src/generator/templates/srv/index.js
+++ b/src/generator/templates/srv/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
+// import socketIO from "socket.io";
 
-export default app => {
+export default (app, http) => {
   // app.use(express.json());
   //
   // app.get('/foo', (req, res) => {
@@ -9,5 +10,15 @@ export default app => {
   //
   // app.post('/bar', (req, res) => {
   //   res.json(req.body);
+  // });
+  // 
+  // optional support for socket.io
+  // 
+  // let io = socketIO(http);
+  // io.on("connection", client => {
+  //   client.on("message", function(data) {
+  //     // do something
+  //   });
+  //   client.emit("message", "Welcome");
   // });
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import listEndpoints from 'express-list-endpoints';
 import history from 'connect-history-api-fallback';
+import httpServer from 'http';
 
 export default ({
   port,
@@ -12,6 +13,7 @@ export default ({
 }) => {
   return new Promise((resolve, reject) => {
     const app = express();
+    const http = httpServer.Server(app);
 
     if (hasTypescript) {
       require('ts-node/register/transpile-only');
@@ -19,20 +21,21 @@ export default ({
 
     const server = loadServer(srvPath);
 
-    server(app);
+    server(app, http);
 
     if (isInProduction && shouldServeApp) {
       app.use(history());
       app.use(express.static(distPath));
     }
 
-    app.listen(port, err => {
+    http.listen(port, err => {
       if (err) {
         reject(err);
       } else {
         resolve(getAppEndpoints(app));
       }
     });
+
   });
 };
 


### PR DESCRIPTION
The http binding is needed by client application to add socket.io support.