### PR TITLE
Fixed ipv4 host binding and sockjs proxy exclusion

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import httpServer from 'http';
 
 export default ({
   port,
+  host,
   srvPath,
   distPath,
   hasTypescript,
@@ -28,7 +29,7 @@ export default ({
       app.use(express.static(distPath));
     }
 
-    http.listen(port, err => {
+    http.listen(port, host, err => {
       if (err) {
         reject(err);
       } else {

--- a/src/servicePlugin/runCommand.js
+++ b/src/servicePlugin/runCommand.js
@@ -1,4 +1,5 @@
 import serverUrl from '../utils/serverUrl';
+import proxyPaths from '../utils/proxyPaths';
 import logSuccessLunch from '../utils/logSuccessLaunch';
 import server from '../server';
 
@@ -13,6 +14,7 @@ export default ({
   const run = async (resolve) => {
     const {
       port,
+      host,
       localUrl,
       networkUrl,
       localUrlForTerminal,
@@ -20,6 +22,7 @@ export default ({
 
     const routes = await server({
       port,
+      host,
       srvPath,
       distPath,
       hasTypescript,
@@ -29,6 +32,7 @@ export default ({
 
     if (shouldServeApp && !isInProduction) {
       serverUrl.writeToFile(localUrl);
+      proxyPaths.writeToFile(routes);
     }
 
     logSuccessLunch({

--- a/src/servicePlugin/serveCommand.js
+++ b/src/servicePlugin/serveCommand.js
@@ -2,6 +2,8 @@ import chalk from 'chalk';
 import nodemon from 'nodemon';
 import { commandOptionsDefaults } from '../config';
 import serverUrl from '../utils/serverUrl';
+import porxyPath from '../utils/proxyPaths';
+import proxyPaths from '../utils/proxyPaths';
 
 export default ({
   srvPath,
@@ -35,6 +37,7 @@ export default ({
     nodemon.on('quit', () => {
       resolve();
       serverUrl.deleteFile();
+      proxyPaths.deleteFile();
       process.exit();
     });
   });

--- a/src/servicePlugin/serveCommand.js
+++ b/src/servicePlugin/serveCommand.js
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import nodemon from 'nodemon';
 import { commandOptionsDefaults } from '../config';
 import serverUrl from '../utils/serverUrl';
-import porxyPath from '../utils/proxyPaths';
 import proxyPaths from '../utils/proxyPaths';
 
 export default ({

--- a/src/servicePlugin/webpackConfig.js
+++ b/src/servicePlugin/webpackConfig.js
@@ -1,12 +1,30 @@
 import serverUrl from '../utils/serverUrl';
+import proxyPaths from '../utils/proxyPaths';
+
 import { done, warn } from '@vue/cli-shared-utils';
 
 export default ({ devServer }) => {
-  if (!serverUrl.isSet()) {
+  if (!serverUrl.isSet() && !proxyPaths.isSet()) {
     warn('You have to launch the express server before ' +
       'if you want to use relative path in your code!', 'Express server');
   } else {
-    devServer.proxy(serverUrl.getFromFile());
+    const url = serverUrl.getFromFile();
+    const routes = proxyPaths.getFromFile();
+
+    let proxyConfig = {
+      '/socket.io': {
+        target: url,
+        ws: true,
+      },
+    };
+
+    for (const route of routes) {
+      proxyConfig[route.path] = {
+        target: url,
+      };
+    }
+
+    devServer.proxy(proxyConfig);
     done('Fallback will be done on your server. You can use relative calls to it in your code.', 'Express server');
   }
 };

--- a/src/utils/proxyPaths.js
+++ b/src/utils/proxyPaths.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+const tmpPath = path.resolve(__dirname, '.tmpProxyPaths');
+
+export default {
+  isSet () {
+    return fs.existsSync(tmpPath);
+  },
+  getFromFile () {
+    return JSON.parse(fs.readFileSync(tmpPath, 'utf8'));
+  },
+  writeToFile (routes) {
+    fs.writeFileSync(tmpPath, JSON.stringify(routes));
+  },
+  deleteFile () {
+    if (this.isSet()) {
+      fs.unlinkSync(tmpPath);
+    }
+  },
+};


### PR DESCRIPTION
Hi,

After initial setup of the plugin I ran into some bugs.

The first bug I identified was the fact that the express server was not binding correctly.

The second being the fact that sockjs was being proxied to the express server even though it should not. While I am not certain I believe sockjs is used for communication between the frontend and devServer.

Both can be seen in the image below.

![Screenshot from 2019-07-09 15-44-03](https://user-images.githubusercontent.com/487887/60984886-6de16800-a30a-11e9-93b0-b03ffa128cf8.png)

**Host Binding Fix**

[Looking at the the server.listen() definition](https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback) we can see that the default behavior is to bind to ipv6 if enabled. Propagating the host variable to the function call fixed this issue.

**Proxy Sockjs Fix**

I did not find an easy way to exclude paths in the proxy definition so I opted to create a proxy spec for each route that should be proxied to the express server. This was done by saving the express routes information in parallel with the serverUrl information.

Result

![Screenshot from 2019-07-10 11-57-00](https://user-images.githubusercontent.com/487887/60985426-7ab28b80-a30b-11e9-8a58-e30aba07e4ae.png)

Thanks for the plugin!
